### PR TITLE
Fix infinite loop when using children set

### DIFF
--- a/classes/OpeningHours/Entity/PostSetProvider.php
+++ b/classes/OpeningHours/Entity/PostSetProvider.php
@@ -43,7 +43,7 @@ class PostSetProvider extends SetProvider {
         $dateEnd = empty($dateEnd) ? null : new \DateTime($dateEnd);
 
         if ($this->childSetCriteriaMatches($dateStart, $dateEnd, $weekScheme)) {
-          $childSet = $this->createSet($childPost);
+          $childSet = $this->createSet($childPost->ID);
           $childSet->setId($post->ID);
           $childSet->setName($post->post_title);
           return $childSet;


### PR DESCRIPTION
Fix infinite loop bug : on line 46, call createSet method with WP_Post object as parameter instead of id (int or string) so the findPost line 25 return the persisted post that is always the same... so infinite loop ;-)